### PR TITLE
Herramientas js

### DIFF
--- a/amd/src/herramientas.js
+++ b/amd/src/herramientas.js
@@ -1,23 +1,137 @@
 // Abstract Herramienta
-class AbstractTool() {
-	constructor() {
+'use strict';
+class AbstractTool {
+  constructor() {
 		if (this.constructor === AbstractTool){
 			throw new TypeError("Cannot construct abstract class");
 		}
-		if (this.update === AbstractTool.prototype.update) {
-			throw new TypeError("Please implement abstract method update");
+		if (this.actualizar === AbstractTool.prototype.actualizar) {
+			throw new TypeError("Please implement abstract method actualizar");
 		}
-		if (this.draw === AbstractTool.prototype.draw) {
-			throw new TypeError("Please implement abstract method draw");
+		if (this.dibujar === AbstractTool.prototype.dibujar) {
+			throw new TypeError("Please implement abstract method dibujar");
 		}
 	}
 
-	update(State) {
-		throw new TypeError("Do not call abstract method update from child");
+	actualizar(estado) {
+		throw new TypeError("Do not call abstract method actualizar from child");
 	}
 
-	draw() {
-		throw new TypeError("Do not call abstract method draw from child");
+	dibujar(ctx) {
+		throw new TypeError("Do not call abstract method dibujar from child");
 	}
 }
 
+class Balanza extends AbstractTool {
+	constructor(){
+		super();
+	}
+
+	actualizar(estado){
+		// TODO 
+		console.log("haha Balanza go brrrr")
+	}
+
+	dibujar(ctx){
+		// var img = obtener imagen de la herramienta
+		// ctx.drawImage(img, 10, 10);
+		ctx.beginPath();
+		ctx.arc(95, 50, 20, 0, 2 * Math.PI);
+		ctx.stroke();
+	}
+}
+
+class CamaraIonizacion extends AbstractTool {
+	constructor(){
+		super();
+	}
+
+	actualizar(estado){
+		// TODO 
+		console.log("haha Camara de Ionizacion go brrrr")
+	}
+
+	dibujar(ctx){
+		// var img = obtener imagen de la herramienta
+		// ctx.drawImage(img, 10, 10);
+		ctx.beginPath();
+		ctx.arc(95, 50, 20, 0, 2 * Math.PI);
+		ctx.stroke();
+	}
+}
+
+class Electrometro extends AbstractTool {
+	constructor(){
+		super();
+	}
+
+	actualizar(estado){
+		// TODO 
+		console.log("haha Electrometro go brrrr")
+	}
+
+	dibujar(ctx){
+		// var img = obtener imagen de la herramienta
+		// ctx.drawImage(img, 10, 10);
+		ctx.beginPath();
+		ctx.arc(95, 50, 20, 0, 2 * Math.PI);
+		ctx.stroke();
+	}
+}
+
+class Termometro extends AbstractTool {
+	constructor(){
+		super();
+	}
+
+	actualizar(estado){
+		// TODO 
+		console.log("haha Termometro go brrrr")
+	}
+
+	dibujar(ctx){
+		// var img = obtener imagen de la herramienta
+		// ctx.drawImage(img, 10, 10);
+		ctx.beginPath();
+		ctx.arc(95, 50, 20, 0, 2 * Math.PI);
+		ctx.stroke();
+	}
+}
+
+class Barometro extends AbstractTool {
+	constructor(){
+		super();
+	}
+
+	actualizar(estado){
+		// TODO 
+		console.log("haha Barometro go brrrr")
+	}
+
+	dibujar(ctx){
+		// var img = obtener imagen de la herramienta
+		// ctx.drawImage(img, 10, 10);
+		ctx.beginPath();
+		ctx.arc(95, 50, 20, 0, 2 * Math.PI);
+		ctx.stroke();
+	}
+}
+
+class CintaMetrica extends AbstractTool {
+	constructor(){
+		super();
+	}
+
+	actualizar(estado){
+		// TODO 
+		console.log("haha CintaMetrica go brrrr")
+	}
+
+	dibujar(ctx){
+		// var img = obtener imagen de la herramienta
+		// ctx.drawImage(img, 10, 10);
+		ctx.beginPath();
+		ctx.arc(95, 50, 20, 0, 2 * Math.PI);
+		ctx.stroke();
+	}
+}

--- a/amd/src/herramientas.js
+++ b/amd/src/herramientas.js
@@ -17,14 +17,34 @@ class AbstractTool {
 		throw new TypeError("Do not call abstract method actualizar from child");
 	}
 
-	dibujar(ctx) {
+	dibujar() {
 		throw new TypeError("Do not call abstract method dibujar from child");
+	}
+
+	getTipo() {
+		return this.tipo
+	}
+}
+
+class BaseNula extends AbstractTool {
+	constructor(){
+		super();
+		this.tipo = "null";
+	}
+
+	actualizar(estado) {
+		console.log("haha BaseNula go brrrr")
+	}
+
+	dibujar(){
+		console.log("dibujar go brrr")
 	}
 }
 
 class Balanza extends AbstractTool {
 	constructor(){
 		super();
+		this.tipo = "balanza"
 	}
 
 	actualizar(estado){
@@ -38,12 +58,15 @@ class Balanza extends AbstractTool {
 		ctx.beginPath();
 		ctx.arc(95, 50, 20, 0, 2 * Math.PI);
 		ctx.stroke();
+		ctx.fillStyle = "red";
+		ctx.fill();
 	}
 }
 
 class CamaraIonizacion extends AbstractTool {
 	constructor(){
 		super();
+		this.tipo = "camIonizacion"
 	}
 
 	actualizar(estado){
@@ -57,12 +80,15 @@ class CamaraIonizacion extends AbstractTool {
 		ctx.beginPath();
 		ctx.arc(95, 50, 20, 0, 2 * Math.PI);
 		ctx.stroke();
+		ctx.fillStyle = "blue";
+		ctx.fill();
 	}
 }
 
 class Electrometro extends AbstractTool {
 	constructor(){
 		super();
+		this.tipo = "electrometro"
 	}
 
 	actualizar(estado){
@@ -76,12 +102,15 @@ class Electrometro extends AbstractTool {
 		ctx.beginPath();
 		ctx.arc(95, 50, 20, 0, 2 * Math.PI);
 		ctx.stroke();
+		ctx.fillStyle = "green";
+		ctx.fill();
 	}
 }
 
 class Termometro extends AbstractTool {
 	constructor(){
 		super();
+		this.tipo = "termometro"
 	}
 
 	actualizar(estado){
@@ -95,12 +124,15 @@ class Termometro extends AbstractTool {
 		ctx.beginPath();
 		ctx.arc(95, 50, 20, 0, 2 * Math.PI);
 		ctx.stroke();
+		ctx.fillStyle = "yellow";
+		ctx.fill();
 	}
 }
 
 class Barometro extends AbstractTool {
 	constructor(){
 		super();
+		this.tipo = "barometro"
 	}
 
 	actualizar(estado){
@@ -114,12 +146,15 @@ class Barometro extends AbstractTool {
 		ctx.beginPath();
 		ctx.arc(95, 50, 20, 0, 2 * Math.PI);
 		ctx.stroke();
+		ctx.fillStyle = "purple";
+		ctx.fill();
 	}
 }
 
 class CintaMetrica extends AbstractTool {
 	constructor(){
 		super();
+		this.tipo = "cinta"
 	}
 
 	actualizar(estado){
@@ -133,5 +168,7 @@ class CintaMetrica extends AbstractTool {
 		ctx.beginPath();
 		ctx.arc(95, 50, 20, 0, 2 * Math.PI);
 		ctx.stroke();
+		ctx.fillStyle = "black";
+		ctx.fill();
 	}
 }

--- a/amd/src/herramientas.js
+++ b/amd/src/herramientas.js
@@ -1,0 +1,23 @@
+// Abstract Herramienta
+class AbstractTool() {
+	constructor() {
+		if (this.constructor === AbstractTool){
+			throw new TypeError("Cannot construct abstract class");
+		}
+		if (this.update === AbstractTool.prototype.update) {
+			throw new TypeError("Please implement abstract method update");
+		}
+		if (this.draw === AbstractTool.prototype.draw) {
+			throw new TypeError("Please implement abstract method draw");
+		}
+	}
+
+	update(State) {
+		throw new TypeError("Do not call abstract method update from child");
+	}
+
+	draw() {
+		throw new TypeError("Do not call abstract method draw from child");
+	}
+}
+


### PR DESCRIPTION
Clases para herramientas:
* Abstracta; solo implementa getTipo
* BaseNula; Extiende clase abstracta. Clase de prueba
* Para el resto de clases falta definir que hace actualizar y dibujar