### PR TITLE
Fix estado herram

### DIFF
--- a/amd/src/maquina.js
+++ b/amd/src/maquina.js
@@ -174,7 +174,10 @@ export default class Maquina {
 
   // Selecciona una nueva herramienta o deselecciona la antigua
   setHerramienta(herram, addon = false) {
-    if (this.alturaCompresor + 5 < herram.altura) {
+    if (this.factorCompresion != this.factorCompresiónini || this.alturaCompresor - 5 < herram.altura) {
+      console.log(this.factorCompresion);
+      console.log(this.factorCompresiónini);
+      console.log(this.factorCompresion != this.factorCompresiónini);
       throw 'No se puede posicionar la herramienta con el compresor tan bajo';
       // return;
     }

--- a/amd/src/maquina.js
+++ b/amd/src/maquina.js
@@ -185,7 +185,6 @@ export default class Maquina {
     }
     else {
 
-
       //La idea es que se compare con un arreglo de herramientas que permiten la vista desde arriba
       if (herram.getTipo() === "Detector de Radiación") {
         //MOSTRAR BOTON
@@ -208,7 +207,7 @@ export default class Maquina {
         this.herramienta = herram;
       }
 
-
+      this.actualizar();
     }
   }
 


### PR DESCRIPTION
1. Herramientas no guardan el estado del momento en que fueron sacadas.
2. Para cambiar de herramientas hay que subir el compresor.