### PR TITLE
Fix: Visor no muestra bien error de fuerza

### DIFF
--- a/amd/src/maquina.js
+++ b/amd/src/maquina.js
@@ -114,7 +114,7 @@ export default class Maquina {
           ? (this.alturaCompresor) * 10
           : 0,
       fuerza: this.factorCompresion > this.factorCompresiónini
-        ? (this.fuerza + this.errorFuerza)
+        ? (this.fuerza + this.errorVisor)
         : 0
     };
   }


### PR DESCRIPTION
Solucionado esto:
![Clipboard 2020-10-12 at 11 28 30 AM](https://user-images.githubusercontent.com/22508602/101794257-73397800-3ae5-11eb-8b18-095dd95dd552.png)
