### PR TITLE
modificado estado de maquina para que contenga miliamperios nominales

### DIFF
--- a/amd/src/herramientas.js
+++ b/amd/src/herramientas.js
@@ -435,7 +435,9 @@ class Fantoma extends AbstractTool {
       this.presionado = false;
     }
     //La configuracion en el panel de control es la adecuada
-    if (parseInt(estado.kilovolt) === 28 && parseInt(estado.miliamperios) === 100) {
+    console.log(estado.miliamperios)
+    console.log(estado.kilovolt)
+    if (parseInt(estado.kilovolt) === 28 && parseInt(estado.miliamperios_nom) === 100) {
       this.parametros = true;
     }
     else {

--- a/amd/src/maquina.js
+++ b/amd/src/maquina.js
@@ -94,6 +94,8 @@ export default class Maquina {
          ? (this.fuerza)
          : 0,
       kilovolt: (this.kilovolt),
+      //para herramienta de fantoma
+      miliamperios_nom : (this.miliamperios),
       miliamperios: this.multiplicar((this.elevar((this.miliamperios),(1+this.errorLinealidad))+ this.mErrorInt(-this.rangemargenmA,this.rangemargenmA)),(1-this.errorRendimiento)),
 
 
@@ -101,7 +103,6 @@ export default class Maquina {
       anodo: this.anodo,
       modo: this.modo,
       activo: isActivo,
-      //para herramienta de fantoma
       
     };
   }


### PR DESCRIPTION
ahora la herramienta fantoma lee los miliampersios del control y no de la maquina, para que este no sea afectado por la pequeña variacion de este valor producida por la aleatoriedad en la repetibilidad